### PR TITLE
add AppVeyor continuous integration build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ The developer [wiki](https://github.com/opendatakit/opendatakit/wiki) (including
 the [**opendatakit**](https://github.com/opendatakit/opendatakit) project.
 
 The Google group for software engineering questions is: [opendatakit-developers@](https://groups.google.com/forum/#!forum/opendatakit-developers)
+
+[![Build status](https://ci.appveyor.com/api/projects/status/q3n9ih86qe0d7pk5?svg=true)](https://ci.appveyor.com/project/lindsay-stevens/validate)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,4 +47,4 @@ deploy:
   prerelease: false
   on:
     branch: master
-    appveyor_repo_tag: false
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   # Download the dependency jars and unpack them into the repository files.
   - ps: $depsUrl = "https://bitbucket.org/javarosa/javarosa/downloads/javarosa-dependencies-r3073.rar"
   - ps: Invoke-WebRequest $depsUrl -OutFile deps.rar
-  - ps: 7z e deps.rar
+  - ps: 7z x deps.rar -y
   
   # Install ant and build javarosa-libraries.jar
   - ps: choco install ant -y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+version: 'build {build}'
+
+environment:
+  global:
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+install:
+  # Install mercurial and clone the javarosa repository from Michael Sundt.
+  - ps: choco install hg -y
+  - ps: $env:Path = "C:\Program Files\Mercurial;" + $env:Path
+  - ps: hg clone https://bitbucket.org/m.sundt/javarosa
+  - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa")
+  
+  # Download the dependency jars and unpack them into the repository files.
+  - ps: $depsUrl = "https://bitbucket.org/javarosa/javarosa/downloads/javarosa-dependencies-r3073.rar"
+  - ps: Invoke-WebRequest $depsUrl -OutFile deps.rar
+  - ps: 7z e deps.rar
+  
+  # Install ant and build javarosa-libraries.jar
+  - ps: choco install ant -y
+  - ps: $env:Path = "C:\ProgramData\bin;" + $env:Path
+  - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa\core")
+  - ps: ant package
+  - ps: cd $env:APPVEYOR_BUILD_FOLDER
+  - ps: copy javarosa\core\dist\javarosa-libraries.jar lib\javarosa-libraries.jar
+
+build_script:
+  - ps: cd $env:APPVEYOR_BUILD_FOLDER
+  - ps: ant package
+
+test: off
+
+artifacts:
+  - path: dist\ODK_Validate.jar
+    name: ODK_Validate.jar
+
+deploy:
+  release:  $(appveyor_build_number)
+  description: 'AppVeyor build of ODK Validate.'
+  provider: GitHub
+  auth_token:
+    secure: NtPZXcWIFDe2fOnxFYxDAlnbiVRuClb3A+wlkdB0iXBuyEbgIQmtRRdHSP4jyacd
+  artifact: ODK_Validate.jar
+  draft: false
+  prerelease: false
+  on:
+    appveyor_repo_tag: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
 install:
   # Install mercurial and clone the javarosa repository from Michael Sundt.
   - ps: choco install hg -y
-  - ps: $env:Path = "C:\Program Files\Mercurial;" + $env:Path
+  - ps: $env:Path = "C:\Program Files\Mercurial;$env:Path"
   - ps: hg clone -u $env:JAVAROSA_TAG https://bitbucket.org/m.sundt/javarosa
-  - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa")
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\javarosa"
   
   # Download the dependency jars and unpack them into the repository files.
   - ps: $depsUrl = "https://bitbucket.org/javarosa/javarosa/downloads/javarosa-dependencies-r3073.rar"
@@ -19,9 +19,9 @@ install:
   
   # Install ant and build javarosa-libraries.jar
   - ps: choco install ant -y --ignore-dependencies
-  - ps: $env:Path = "C:\Program Files\Java\jdk1.8.0\bin;" + $env:Path
-  - ps: $env:Path = "C:\ProgramData\bin;" + $env:Path
-  - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa\core")
+  - ps: $env:Path = "C:\Program Files\Java\jdk1.8.0\bin;$env:Path"
+  - ps: $env:Path = "C:\ProgramData\bin;$env:Path"
+  - ps: cd "$env:APPVEYOR_BUILD_FOLDER\javarosa\core"
   - ps: ant package
   - ps: cd $env:APPVEYOR_BUILD_FOLDER
   - ps: copy javarosa\core\dist\javarosa-libraries.jar lib\javarosa-libraries.jar
@@ -37,7 +37,7 @@ artifacts:
     name: ODK_Validate.jar
 
 deploy:
-  release:  $(APPVEYOR_REPO_TAG_NAME) build $(appveyor_build_number)
+  release: $(APPVEYOR_REPO_TAG_NAME)
   description: 'AppVeyor build of ODK Validate.'
   provider: GitHub
   auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 'build {build}'
 
 environment:
   global:
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0\bin
 
 install:
   # Install mercurial and clone the javarosa repository from Michael Sundt.
@@ -17,7 +17,8 @@ install:
   - ps: 7z x deps.rar -y
   
   # Install ant and build javarosa-libraries.jar
-  - ps: choco install ant -y
+  - ps: choco install ant -y --ignore-dependencies
+  - ps: $env:Path = "C:\Program Files\Java\jdk1.8.0\bin;" + $env:Path
   - ps: $env:Path = "C:\ProgramData\bin;" + $env:Path
   - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa\core")
   - ps: ant package

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,14 @@ version: 'build {build}'
 environment:
   global:
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0\bin
+    JAVAROSA_TAG: javarosa-2016-04-21.jar
+    RELEASE_TITLE: v1.4.6_for_ODK_Collect_v1.4.6_and_newer
 
 install:
   # Install mercurial and clone the javarosa repository from Michael Sundt.
   - ps: choco install hg -y
   - ps: $env:Path = "C:\Program Files\Mercurial;" + $env:Path
-  - ps: hg clone https://bitbucket.org/m.sundt/javarosa
+  - ps: hg clone -u $env:JAVAROSA_TAG https://bitbucket.org/m.sundt/javarosa
   - ps: cd ($env:APPVEYOR_BUILD_FOLDER + "\javarosa")
   
   # Download the dependency jars and unpack them into the repository files.
@@ -36,7 +38,7 @@ artifacts:
     name: ODK_Validate.jar
 
 deploy:
-  release:  $(appveyor_build_number)
+  release:  $(RELEASE_TITLE) build $(appveyor_build_number)
   description: 'AppVeyor build of ODK Validate.'
   provider: GitHub
   auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   global:
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0\bin
     JAVAROSA_TAG: javarosa-2016-04-21.jar
-    RELEASE_TITLE: v1.4.6_for_ODK_Collect_v1.4.6_and_newer
 
 install:
   # Install mercurial and clone the javarosa repository from Michael Sundt.
@@ -38,7 +37,7 @@ artifacts:
     name: ODK_Validate.jar
 
 deploy:
-  release:  $(RELEASE_TITLE) build $(appveyor_build_number)
+  release:  $(APPVEYOR_REPO_TAG_NAME) build $(appveyor_build_number)
   description: 'AppVeyor build of ODK Validate.'
   provider: GitHub
   auth_token:
@@ -47,4 +46,5 @@ deploy:
   draft: false
   prerelease: false
   on:
+    branch: master
     appveyor_repo_tag: false

--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
 		<javac srcdir="src/" destdir="bin/" classpathref="classpath" debug="true" debuglevel="lines,source" source="1.5" target="1.5"/>
 	</target>
 	<target name="package" depends="compile" description="package source and binary into jar">
-		<jar destfile="dist/ODK Validate.jar">
+		<jar destfile="dist/ODK_Validate.jar">
 			<fileset dir="bin/" includes="**/*.class"/>
 			<zipfileset src="./lib/javarosa-libraries.jar" includes="**/*.class"/>
 			<zipfileset src="./lib/kxml2-2.3.0.jar" includes="**/*.class"/>


### PR DESCRIPTION
I have a project where I've made a python GUI for Windows [0] that helps us work through some of the steps in using XLSForms. Part of that is using ODK_Validate to check the pyxform output is valid. 

For my project I came to grips with AppVeyor CI to standardise the preparation of a standalone executable for Windows. I thought it might be helpful if ODK_Validate had something similar, particularly for collecting the javarosa dependencies.

This pull request adds an AppVeyor CI config for building ODK_Validate.jar. The Javarosa library dependency is also built automatically, using the m.sundt fork. Releases are triggered on push of a new tag, and are uploaded as a release for that tag in GitHub. The JAVAROSA_TAG variable at the top of the appveyor.yml script determines which tag to checkout after cloning the m.sundt javarosa repository.

I have successfully run it in my fork [1], if you want to see what the release looks like. 

However, to use this, the owner (or someone with commit privileges) of the opendatakit/validate repository would need to complete a couple of steps [2,3] to enable AppVeyor builds in the official repository, part of which is to replace the encrypted auth_token at the bottom of the file. Importantly, the GitHub webhook settings should be for only the "push" event, not "pull request" as well, since having both will trigger 2x builds per pushed commit. If desired, the build can be set as a check before any pull request, by going in to GitHub settings and protecting the "master" branch and selecting the AppVeyor status check.

Lastly, I added a build status badge in the README file. The URL should be updated to point to the AppVeyor project corresponding to the official repository. The link for it will be in the AppVeyor project page, under "badges".

[0] https://github.com/lindsay-stevens/odk_tools
[1] https://github.com/lindsay-stevens/validate/releases
[2] http://www.appveyor.com/docs
[3] http://www.appveyor.com/docs/deployment/github
