### PR TITLE
Make FormValidator a little easier to integrate with another java app

### DIFF
--- a/src/org/opendatakit/validate/ErrorListener.java
+++ b/src/org/opendatakit/validate/ErrorListener.java
@@ -1,0 +1,26 @@
+package org.opendatakit.validate;
+
+public interface ErrorListener {
+
+    void error(Object err);
+
+    void error(Object err, Throwable t);
+
+    void info(Object msg);
+
+    ErrorListener DEFAULT_ERROR_LISTENER = new ErrorListener() {
+        public void error(Object err) {
+            System.err.println(err);
+        }
+
+        public void error(Object err, Throwable t) {
+            System.err.println(err);
+            t.printStackTrace();
+        }
+
+        public void info(Object msg) {
+            System.out.println(msg);
+        }
+
+    };
+}


### PR DESCRIPTION
Hi,

I wish to integrate this ""validate"" with our java based in-house [xform](https://github.com/kayr/xform-markup-editor) generator. I made a few changes to `FormValidator` to make it easier for this process. 

I basically just Replaced all `System.err.println` with `errorlistener.error() or info()`. Also added 2 more validate methods. i.e `validateText(xform)` and `validate(InputStream)`

Just thought these changes could also be useful to someone else.

...
Ronald
