### PR TITLE
Upgrade to JavaRosa 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = '1.7'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.1.0'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.2.0'
 }
 
 // Required to use fileExtensions property in checkstyle file


### PR DESCRIPTION
* Confirmed working by validating [range.xml.txt](https://github.com/opendatakit/validate/files/1034449/range.xml.txt) does not show any warnings.
