### PR TITLE
UI of the validate application now feels modern

### DIFF
--- a/src/org/opendatakit/validate/FormValidator.java
+++ b/src/org/opendatakit/validate/FormValidator.java
@@ -44,6 +44,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.javarosa.core.model.Constants;
@@ -120,12 +122,28 @@ public class FormValidator implements ActionListener {
 
 
     public static void main(String[] args) {
-        if ( args.length == 1 ) {
-            String path = args[0];
-            new FormValidator().validateAndExitWithErrorCode(path);
-        } else {
-            new FormValidator().show();
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            if (args.length == 1) {
+                String path = args[0];
+                new FormValidator().validateAndExitWithErrorCode(path);
+            } else {
+                new FormValidator().show();
+            }
         }
+        catch (UnsupportedLookAndFeelException e) {
+            e.printStackTrace();
+        }
+        catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+        catch (InstantiationException e) {
+            e.printStackTrace();
+        }
+        catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
     }
 
 


### PR DESCRIPTION
Closes #48 

#### What has been done to verify that this works as intended?
The application was ran on Ubuntu 16.04 & Windows 10. In both cases the theme of the application matched the OS it was running in. Apart from this `./gradlew check` ran successfully.

#### Why is this the best possible solution? Were any other approaches considered?
WIth a single line of code, the application is able to adjust its appearance according to the operating system it's being run in. 

#### Are there any risks to merging this code? If so, what are they?
The application runs smoothly on most OS's. However if not listed here [How to Set the Look and Feel](https://docs.oracle.com/javase/tutorial/uiswing/lookandfeel/plaf.html), it's expected that the application will crash.