### PR TITLE
Introduction of SLF4J requires Validate to specify logging behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ sourceCompatibility = '1.7'
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.11.0'
+    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
 }
 
 // Required to use fileExtensions property in checkstyle file


### PR DESCRIPTION
Addresses https://github.com/XLSForm/pyxform/pull/213

#### What has been done to verify that this works as intended?
Confirmed jar builds and shows errors in UI for XML errors and XForm errors

#### Why is this the best possible solution? Were any other approaches considered?
I *think* this change makes it so any error messages that JavaRosa wants to log are discarded. I think is what Validate has always done, so this change is more about maintaining the status quote.

#### Are there any risks to merging this code? If so, what are they?
Yes! We might want the JavaRosa logs to appear somewhere. Also, my understanding of slf4j might be totally wrong.