### PR TITLE
Update to JavaRosa v2.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = '1.7'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.12.1'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.13.0'
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
 }
 


### PR DESCRIPTION
I reviewed https://github.com/opendatakit/javarosa/releases/tag/v2.13.0 and it should be pretty safe.

Maybe https://github.com/opendatakit/javarosa/commit/470c7645a61b1dca3ebc6afb3b0f416045ae845b might be a problem?