### PR TITLE
Replace spaces with dashes to match preferred binary name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ mainClassName = 'org.opendatakit.validate.FormValidator'
 jar {
     baseName = buildConfig.appName
     version = buildConfig.version
-    archiveName = baseName + ' ' + version + '.jar'
+    archiveName = (baseName + ' ' + version + '.jar').replaceAll(" ","-")
 
     from {
         configurations.compile.collect {


### PR DESCRIPTION
When we upload the build to GH, it replaces spaces with periods. We then have to edit the binary file name. Changing the gradle file ensures we don't have to do this manual step.