### PR TITLE
Add stubs so external secondary instances can pass validation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ sourceSets {
         java {
             srcDirs = ['src']
         }
+
+        resources {
+            srcDirs = ['resources']
+        }
     }
 }
 

--- a/resources/fake-itemset.xml
+++ b/resources/fake-itemset.xml
@@ -1,0 +1,6 @@
+<root>
+    <item>
+        <name>an-item</name>
+        <label>An Item</label>
+    </item>
+</root>

--- a/src/org/opendatakit/validate/FormValidator.java
+++ b/src/org/opendatakit/validate/FormValidator.java
@@ -60,6 +60,7 @@ import org.javarosa.core.model.instance.InstanceInitializationFactory;
 import org.javarosa.core.model.instance.InvalidReferenceException;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.core.model.utils.IPreloadHandler;
+import org.javarosa.core.reference.ReferenceManager;
 import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
@@ -421,6 +422,10 @@ public class FormValidator implements ActionListener {
             // needed to override rms property manager
             org.javarosa.core.services.PropertyManager
                     .setPropertyManager(new StubPropertyManager());
+
+            // For forms with external secondary instances
+            final ReferenceManager referenceManager = ReferenceManager.instance();
+            referenceManager.addReferenceFactory(new StubReferenceFactory());
 
             // validate if the xform can be parsed.
             try {

--- a/src/org/opendatakit/validate/StubReference.java
+++ b/src/org/opendatakit/validate/StubReference.java
@@ -1,0 +1,91 @@
+package org.opendatakit.validate;
+
+import org.javarosa.core.reference.Reference;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.net.URISyntaxException;
+
+/**
+ * Provides the local URI of a simple XML document. This allows forms with external secondary instances to
+ * pass validation.
+ *
+ * The fake instance has the following structure:
+ *
+ * <pre>{@code
+ * <root>
+ *     <item>
+ *         <name>an-item</name>
+ *         <label>An Item</label>
+ *     </item>
+ * </root>
+ *}</pre>
+ *
+ * This means only itemset declarations that define {@code name} as the node name referring to the select underlying
+ * value and {@code label} as the node name referring to the label will pass validation.
+ *
+ * Passes validation:
+ * <pre>{@code
+ *  <itemset nodeset="instance('lgas')/root/item[state=/nigeria_wards_external/state]">
+ *    <value ref="name"/>
+ *    <label ref="label"/>
+ *  </itemset>
+ * }</pre>
+ *
+ * Fails validation:
+ * <pre>{@code
+ *  <itemset nodeset="instance('lgas')/root/item[state=/nigeria_wards_external/state]">
+ *    <value ref="value"/>
+ *    <label ref="something-else"/>
+ *  </itemset>
+ * }</pre>
+ *
+ *
+ *
+ */
+public class StubReference implements Reference {
+    @Override
+    public boolean doesBinaryExist() {
+        return true;
+    }
+
+    @Override
+    public InputStream getStream() {
+        return null;
+    }
+
+    @Override
+    public String getURI() {
+        return null;
+    }
+
+    @Override
+    public String getLocalURI() {
+        try {
+            return getClass().getClassLoader().getResource("fake-itemset.xml").toURI().getPath();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return null;
+    }
+
+    @Override
+    public void remove() {
+
+    }
+
+    @Override
+    public Reference[] probeAlternativeReferences() {
+        return new Reference[0];
+    }
+}

--- a/src/org/opendatakit/validate/StubReferenceFactory.java
+++ b/src/org/opendatakit/validate/StubReferenceFactory.java
@@ -1,0 +1,26 @@
+package org.opendatakit.validate;
+
+import org.javarosa.core.reference.Reference;
+import org.javarosa.core.reference.ReferenceFactory;
+
+/**
+ * Always provides a reference to the same simple XML document. This allows forms with external secondary instances to
+ * pass validation.
+ */
+public class StubReferenceFactory implements ReferenceFactory {
+
+    @Override
+    public boolean derives(String URI) {
+        return true;
+    }
+
+    @Override
+    public Reference derive(String URI) {
+        return new StubReference();
+    }
+
+    @Override
+    public Reference derive(String URI, String context) {
+        return new StubReference();
+    }
+}


### PR DESCRIPTION
Closes #65 

#### What has been done to verify that this works as intended?
I validated the Nigeria Wards form from the issue and verified that it now passes validation.

#### Why is this the best possible solution? Were any other approaches considered?
It's the simplest fix I could think of that doesn't require JavaRosa changes. 

An alternative I considered was avoiding the items verification in `stepThroughEntireForm` for external itemsets. Unfortunately I can't see any way to do that because whether the itemset is internal or external is lost on parse. We'd have to do something like add a field to `ItemsetBinding`. I also considered removing those checks altogether but I think they're useful for more typical form designs.

This approach narrowly supports the typical case generated by `pyxform` where the `itemset` `value` ref is `name` and the `label` ref is `label`. It does not support arbitrary node references for those. Currently, the only way to have different references for those is to author forms by hand and that's very uncommon so I think it's a reasonable fix for now. We may need to revisit later but until external secondary instances are in broader use, I don't think it's worth it.

#### Are there any risks to merging this code? If so, what are they?
With this change, any file reference in a form will get interpreted as referring to the new `fake-itemset.xml` file. Maybe that could mess up forms with media references somehow? I don't think those are touched at all, though, so overall this should be very low risk.