### PR TITLE
Add a Gradle plugin to get Idea identify where the BuildConfig class is

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'checkstyle'
+    id 'idea'
     id 'de.fuerstenau.buildconfig' version '1.1.8'
 }
 


### PR DESCRIPTION
This PR adds the `idea` Gradle plugin that makes working with the BuildConfig plugin easier. Now Idea detects and links the sources for the `BuildConfig` class without requiring to add it to the project manually.