### PR TITLE
Support non standard itemset value and label refs and external instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ sourceSets {
     main {
         java {
             srcDirs = ['src']
+            exclude 'test'
         }
 
         resources {

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
     compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.13.0'
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
 // Required to use fileExtensions property in checkstyle file

--- a/src/test/java/org/opendatakit/validate/ValidateExternalSecondaryInstancesTest.java
+++ b/src/test/java/org/opendatakit/validate/ValidateExternalSecondaryInstancesTest.java
@@ -1,0 +1,70 @@
+package org.opendatakit.validate;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+
+public class ValidateExternalSecondaryInstancesTest {
+    @Test
+    public void supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances() throws URISyntaxException {
+        final Path path = getPathOf("external_secondary_instance_non_standard_use.xml");
+        final FormValidator validator = new FormValidator();
+
+        Output output = Output.runAndGet(new Runnable() {
+            @Override
+            public void run() {
+                validator.validate(path.toString());
+            }
+        });
+        assertThat(output.err, isEmptyString());
+        assertThat(output.std, containsString("Xform is valid"));
+    }
+
+    private Path getPathOf(String filename) throws URISyntaxException {
+        return Paths.get(ValidateExternalSecondaryInstancesTest.class.getResource(filename.startsWith("/") ? filename : "/" + filename).toURI());
+    }
+
+    static class Output {
+        private final String std;
+        private final String err;
+
+        Output(String std, String err) {
+            this.std = std;
+            this.err = err;
+        }
+
+        static Output runAndGet(Runnable runnable) {
+            PrintStream outBackup = System.out;
+            ByteArrayOutputStream stdBaos = new ByteArrayOutputStream();
+            PrintStream stdPs = new PrintStream(stdBaos);
+            System.setOut(stdPs);
+
+            PrintStream errBackup = System.err;
+            ByteArrayOutputStream errBaos = new ByteArrayOutputStream();
+            PrintStream errPs = new PrintStream(errBaos);
+            System.setErr(errPs);
+
+            runnable.run();
+
+            stdPs.flush();
+            String std = stdBaos.toString();
+            System.setOut(outBackup);
+            System.out.print(std);
+
+            errPs.flush();
+            String err = errBaos.toString();
+            System.setErr(errBackup);
+            System.err.print(err);
+
+            return new Output(std, err);
+        }
+    }
+
+}

--- a/src/test/resources/external_secondary_instance_non_standard_use.xml
+++ b/src/test/resources/external_secondary_instance_non_standard_use.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>External Secondary Instance with xslforms generated itemset value/label refs</h:title>
+        <model>
+            <instance>
+                <data id="external-choices">
+                    <some-value/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="external-choices" src="jr://file/external-choices.xml"/>
+            <bind nodeset="/data/some-value" type="select1"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/some-value">
+            <label>Value 1</label>
+            <itemset nodeset="instance('external-choices')/root/item">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #65

This PR goes one step further towards generic support for external instance by creating a synthetic external instance that would have all the refs required by the form, thus passing validation.

#### What has been done to verify that this works as intended?
Added unit tests that verify this claim.

#### Why is this the best possible solution? Were any other approaches considered?
This could be considered hacky because it involves using regular expressions to configure the StubReferenceManager. 

I considered parsing the form with KXML2 and then searching for those ref names in the `<body>` element. This would be less brittle than using regexps, but it felt like we would only get marginal benefits in exchange of making the search code much more complicated.

#### Are there any risks to merging this code? If so, what are they?
Although the regexps have safety whitespace placeholders to account for weird formattings, it won't detect ref names correctly when the `value` and `label` elements use more than one line:
```xml
<value
   ref="some-ref"/>
```

Odds that this happens feel low, though.

The regexps could be missing other unidentified common use cases.