### PR TITLE
Update JavaRosa to 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ sourceCompatibility = '1.7'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.13.0'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.14.0'
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
 }
 


### PR DESCRIPTION
Routine update in preparation for release. JavaRosa 2.14.0 has been in Collect for a while now so this is low-risk.