### PR TITLE
Load extension specific itemset

### DIFF
--- a/resources/fake-itemset.csv
+++ b/resources/fake-itemset.csv
@@ -1,0 +1,2 @@
+name,label
+a-csv-item, "A CSV Item"

--- a/resources/fake-itemset.xml
+++ b/resources/fake-itemset.xml
@@ -1,6 +1,6 @@
 <root>
     <item>
-        <name>an-item</name>
-        <label>An Item</label>
+        <name>an-xml-item</name>
+        <label>An XML Item</label>
     </item>
 </root>

--- a/src/org/opendatakit/validate/StubReference.java
+++ b/src/org/opendatakit/validate/StubReference.java
@@ -8,18 +8,25 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 
 /**
- * Provides the local URI of a simple XML document. This allows forms with external secondary instances to
+ * Provides the local URI of a simple XML or CSV document. This allows forms with external secondary instances to
  * pass validation.
  *
- * The fake instance has the following structure:
+ * The fake XML instance has the following structure:
  *
  * <pre>{@code
  * <root>
  *     <item>
- *         <name>an-item</name>
- *         <label>An Item</label>
+ *         <name>an-xml-item</name>
+ *         <label>An XML Item</label>
  *     </item>
  * </root>
+ *}</pre>
+ *
+ * The fake CSV instance has the following structure:
+ *
+ * <pre>{@code
+ * name,label
+ * a-csv-item, "A CSV Item"
  *}</pre>
  *
  * This means only itemset declarations that define {@code name} as the node name referring to the select underlying
@@ -45,6 +52,13 @@ import java.net.URISyntaxException;
  *
  */
 public class StubReference implements Reference {
+
+    private String uri;
+
+    public StubReference(String URI) {
+        uri = URI;
+    }
+
     @Override
     public boolean doesBinaryExist() {
         return true;
@@ -63,7 +77,13 @@ public class StubReference implements Reference {
     @Override
     public String getLocalURI() {
         try {
-            return getClass().getClassLoader().getResource("fake-itemset.xml").toURI().getPath();
+            if (uri.toLowerCase().startsWith("jr://file/")) {
+                return getClass().getClassLoader().getResource("fake-itemset.xml").toURI().getPath();
+            } else if (uri.toLowerCase().startsWith("jr://file-csv/")) {
+                return getClass().getClassLoader().getResource("fake-itemset.csv").toURI().getPath();
+            } else {
+                return null;
+            }
         } catch (URISyntaxException e) {
             return null;
         }

--- a/src/org/opendatakit/validate/StubReferenceFactory.java
+++ b/src/org/opendatakit/validate/StubReferenceFactory.java
@@ -4,7 +4,7 @@ import org.javarosa.core.reference.Reference;
 import org.javarosa.core.reference.ReferenceFactory;
 
 /**
- * Always provides a reference to the same simple XML document. This allows forms with external secondary instances to
+ * Always provides a reference to the same simple XML or CSV document. This allows forms with external secondary instances to
  * pass validation.
  */
 public class StubReferenceFactory implements ReferenceFactory {
@@ -16,11 +16,11 @@ public class StubReferenceFactory implements ReferenceFactory {
 
     @Override
     public Reference derive(String URI) {
-        return new StubReference();
+        return new StubReference(URI);
     }
 
     @Override
     public Reference derive(String URI, String context) {
-        return new StubReference();
+        return new StubReference(URI);
     }
 }

--- a/src/test/java/org/opendatakit/validate/ValidateExternalSecondaryInstancesTest.java
+++ b/src/test/java/org/opendatakit/validate/ValidateExternalSecondaryInstancesTest.java
@@ -13,8 +13,17 @@ import org.junit.Test;
 
 public class ValidateExternalSecondaryInstancesTest {
     @Test
-    public void supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances() throws URISyntaxException {
-        final Path path = getPathOf("external_secondary_instance_non_standard_use.xml");
+    public void supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances_xml() throws URISyntaxException {
+        supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances("external_secondary_instance_xml.xml");
+    }
+
+    @Test
+    public void supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances_csv() throws URISyntaxException {
+        supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances("external_secondary_instance_csv.xml");
+    }
+
+    private void supports_xlsforms_value_and_label_refs_in_itemsets_using_secondary_external_instances(String secondaryInstancePath) throws URISyntaxException  {
+        final Path path = getPathOf(secondaryInstancePath);
         final FormValidator validator = new FormValidator();
 
         Output output = Output.runAndGet(new Runnable() {

--- a/src/test/resources/external_secondary_instance_csv.xml
+++ b/src/test/resources/external_secondary_instance_csv.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
     <h:head>
-        <h:title>External Secondary Instance with xslforms generated itemset value/label refs</h:title>
+        <h:title>External Secondary Instance with xlsforms generated itemset value/label refs</h:title>
         <model>
             <instance>
                 <data id="external-choices">
@@ -11,7 +11,7 @@
                     </meta>
                 </data>
             </instance>
-            <instance id="external-choices" src="jr://file/external-choices.xml"/>
+            <instance id="external-choices" src="jr://file-csv/external-choices.csv"/>
             <bind nodeset="/data/some-value" type="select1"/>
             <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
         </model>

--- a/src/test/resources/external_secondary_instance_xml.xml
+++ b/src/test/resources/external_secondary_instance_xml.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>External Secondary Instance with xlsforms generated itemset value/label refs</h:title>
+        <model>
+            <instance>
+                <data id="external-choices">
+                    <some-value/>
+                    <meta>
+                        <instanceID/>
+                    </meta>
+                </data>
+            </instance>
+            <instance id="external-choices" src="jr://file/external-choices.xml"/>
+            <bind nodeset="/data/some-value" type="select1"/>
+            <bind calculate="concat('uuid:', uuid())" nodeset="/data/meta/instanceID" readonly="true()" type="string"/>
+        </model>
+    </h:head>
+    <h:body>
+        <select1 ref="/data/some-value">
+            <label>Value 1</label>
+            <itemset nodeset="instance('external-choices')/root/item">
+                <value ref="name"/>
+                <label ref="label"/>
+            </itemset>
+        </select1>
+    </h:body>
+</h:html>


### PR DESCRIPTION
Closes #73

* Added fake CSV itemset
* Changed itemset contents to make debugging easier
* Pass URI into StubReference and use last three characters to load appropriate itemset
* Parameterize existing test
* s/xslforms/xlsforms

Some concerns for a reviewer
* Make sure variable naming and case is correct
* I added a default constructor, but I'm not sure it's needed.

#### What has been done to verify that this works as intended?
Passes tests

#### Why is this the best possible solution? Were any other approaches considered?
JavaRosa loads a [different parser for the secondary instance](https://github.com/opendatakit/javarosa/blob/59611cc0755dfbaf6631866ff15d6a9a516df704/src/main/java/org/javarosa/core/model/instance/ExternalDataInstance.java#L58) based on if the src path contains `file-csv`.  Unless we change this behavior in JR, loading extension specific itemsets is our only reasonable option.

#### Are there any risks to merging this code? If so, what are they?
Nothing really. Maybe we should change the behavior in JR? But that seems more risky to me.