### PR TITLE
getResource cannot be used when accessing files inside jar

### DIFF
--- a/src/org/opendatakit/validate/StubReference.java
+++ b/src/org/opendatakit/validate/StubReference.java
@@ -2,10 +2,11 @@ package org.opendatakit.validate;
 
 import org.javarosa.core.reference.Reference;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.IOException;
 import java.io.OutputStream;
-
-import java.net.URISyntaxException;
 
 /**
  * Provides the local URI of a simple XML or CSV document. This allows forms with external secondary instances to
@@ -76,15 +77,11 @@ public class StubReference implements Reference {
 
     @Override
     public String getLocalURI() {
-        try {
-            if (uri.toLowerCase().startsWith("jr://file/")) {
-                return getClass().getClassLoader().getResource("fake-itemset.xml").toURI().getPath();
-            } else if (uri.toLowerCase().startsWith("jr://file-csv/")) {
-                return getClass().getClassLoader().getResource("fake-itemset.csv").toURI().getPath();
-            } else {
-                return null;
-            }
-        } catch (URISyntaxException e) {
+        if (uri.toLowerCase().startsWith("jr://file/")) {
+            return getResourceAsFile("fake-itemset.xml").toURI().getPath();
+        } else if (uri.toLowerCase().startsWith("jr://file-csv/")) {
+            return getResourceAsFile("fake-itemset.csv").toURI().getPath();
+        } else {
             return null;
         }
     }
@@ -107,5 +104,34 @@ public class StubReference implements Reference {
     @Override
     public Reference[] probeAlternativeReferences() {
         return new Reference[0];
+    }
+
+    // getResource() on a file will fail when Validate is run as a jar.
+    // getResourceAsStream() is the workaround, but because we need a path,
+    // we need to copy the stream to a temp file. The temp file is deleted
+    // when the JVM exits
+    // https://stackoverflow.com/a/35466006/152938
+    private static File getResourceAsFile(String resourcePath) {
+        try {
+            InputStream in = ClassLoader.getSystemClassLoader().getResourceAsStream(resourcePath);
+            if (in == null) {
+                return null;
+            }
+
+            File tempFile = File.createTempFile(String.valueOf(in.hashCode()), ".tmp");
+            tempFile.deleteOnExit();
+
+            try (FileOutputStream out = new FileOutputStream(tempFile)) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, bytesRead);
+                }
+            }
+            return tempFile;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Addresses #74 

#### What has been done to verify that this works as intended?
Ran `./gradlew {run|test|jar}` and confirmed everything worked.

#### Why is this the best possible solution? Were any other approaches considered?
Narrowest change that doesn't touch JR.

#### Are there any risks to merging this code? If so, what are they?
Not really. Seems to be the standard way to do these sorts of things.