### PR TITLE
Add description of what validation is performed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ ODK Validate is part of Open Data Kit (ODK), a free and open-source set of tools
 * ODK developer Slack archive: [http://opendatakit.slackarchive.io](http://opendatakit.slackarchive.io) 
 * ODK developer wiki: [https://github.com/opendatakit/opendatakit/wiki](https://github.com/opendatakit/opendatakit/wiki)
 
+## What validation is performed
+Validate is a thin wrapper over the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Given an XML document representing an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition, Validate uses JavaRosa to first parse that form document into an in-memory representation and then it goes through that in-memory representation like a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
+
+In general, issues with how the validation is done or what errors get presented are JavaRosa issues and should be filed [in its repository](https://github.com/opendatakit/javarosa/).
+
 ## Setting up your development environment
 
 1. Fork the validate project ([why and how to fork](https://help.github.com/articles/fork-a-repo/))

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To package a runnable jar, use the `jar` Gradle task.
 
 ## How Validate validates
 
-Validate is a thin wrapper of the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Validate uses JavaRosa to parse an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition into an in-memory representation. Validate then goes through the in-memory representation in the same way a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
+Validate is a thin wrapper around the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Validate uses JavaRosa to parse an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition into an in-memory representation. Validate then goes through the in-memory representation in the same way a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
 
 Validate does not simulate entering any data. Expressions that are not reached when first displaying a form are not verified. For example, if an `if` call has an invalid function call in one of its branches such as `if (/data/my_var = 'yes', invalid-function('bad', 'bad'), 0)`, Validate will not identify that unless the default value for `my_var` is `yes`.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ODK Validate is part of Open Data Kit (ODK), a free and open-source set of tools
 ## What validation is performed
 Validate is a thin wrapper over the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Given an XML document representing an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition, Validate uses JavaRosa to first parse that form document into an in-memory representation and then it goes through that in-memory representation like a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
 
+Validate does not simulate entering any data or perform static analysis on expressions so expressions that are not reached when first displaying a form are not verified. For example, if an `if` function call has a problematic call in one of its branches such as `if (/data/my_var = 'yes', fake-function('bad', 'bad'), 0)`, Validate will not identify that unless the default value for `my_var` is `yes`.
+
 In general, issues with how the validation is done or what errors get presented are JavaRosa issues and should be filed [in its repository](https://github.com/opendatakit/javarosa/).
 
 ## Setting up your development environment

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 ODK Validate is a desktop Java application for confirming that a form is compliant with the [ODK XForms spec](http://opendatakit.github.io/xforms-spec).
    
-
 ODK Validate is part of Open Data Kit (ODK), a free and open-source set of tools which help organizations author, field, and manage mobile data collection solutions. Learn more about the Open Data Kit project and its history [here](https://opendatakit.org/about/) and read about example ODK deployments [here](https://opendatakit.org/about/deployments/).
 
 * ODK website: [https://opendatakit.org](https://opendatakit.org)
@@ -15,13 +14,6 @@ ODK Validate is part of Open Data Kit (ODK), a free and open-source set of tools
 * ODK developer Slack chat: [http://slack.opendatakit.org](http://slack.opendatakit.org) 
 * ODK developer Slack archive: [http://opendatakit.slackarchive.io](http://opendatakit.slackarchive.io) 
 * ODK developer wiki: [https://github.com/opendatakit/opendatakit/wiki](https://github.com/opendatakit/opendatakit/wiki)
-
-## What validation is performed
-Validate is a thin wrapper over the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Given an XML document representing an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition, Validate uses JavaRosa to first parse that form document into an in-memory representation and then it goes through that in-memory representation like a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
-
-Validate does not simulate entering any data or perform static analysis on expressions so expressions that are not reached when first displaying a form are not verified. For example, if an `if` function call has a problematic call in one of its branches such as `if (/data/my_var = 'yes', fake-function('bad', 'bad'), 0)`, Validate will not identify that unless the default value for `my_var` is `yes`.
-
-In general, issues with how the validation is done or what errors get presented are JavaRosa issues and should be filed [in its repository](https://github.com/opendatakit/javarosa/).
 
 ## Setting up your development environment
 
@@ -42,6 +34,14 @@ To run the project, go to the `View` menu, then `Tool Windows > Gradle`. `run` w
 You must use the Gradle task to run the application because there is a generated class (`BuildConfig`) that IntelliJ may not properly import and recognize.
 
 To package a runnable jar, use the `jar` Gradle task.
+
+## How Validate validates
+
+Validate is a thin wrapper of the [JavaRosa](https://github.com/opendatakit/javarosa/) form parsing library. Validate uses JavaRosa to parse an [ODK XForms](https://opendatakit.github.io/xforms-spec/) form definition into an in-memory representation. Validate then goes through the in-memory representation in the same way a client such as [Collect](https://github.com/opendatakit/collect) would. This simulates displaying questions to the user and exercises the logic in the form. Errors detected by JavaRosa are presented to the user.
+
+Validate does not simulate entering any data. Expressions that are not reached when first displaying a form are not verified. For example, if an `if` call has an invalid function call in one of its branches such as `if (/data/my_var = 'yes', invalid-function('bad', 'bad'), 0)`, Validate will not identify that unless the default value for `my_var` is `yes`.
+
+In general, issues with validation or what errors get presented are JavaRosa issues and should be filed [in its repository](https://github.com/opendatakit/javarosa/).
 
 ## Integrating Validate with your Java app
 


### PR DESCRIPTION
Provides a bit more context on what Validate actually does. In particular, the fact that the form is actually walked through is not obvious.