### PR TITLE
Register stub setgeopoint implementation that does nothing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.15.0'
+    compile group: 'org.opendatakit', name: 'opendatakit-javarosa', version: '2.15.1'
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-all:1.3'

--- a/src/org/opendatakit/validate/FormValidator.java
+++ b/src/org/opendatakit/validate/FormValidator.java
@@ -68,6 +68,7 @@ import org.javarosa.form.api.FormEntryModel;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XFormsModule;
 import org.javarosa.xform.parse.XFormParseException;
+import org.javarosa.xform.parse.XFormParser;
 import org.javarosa.xform.util.XFormUtils;
 
 import org.opendatakit.validate.buildconfig.BuildConfig;
@@ -452,6 +453,9 @@ public class FormValidator implements ActionListener {
             // For forms with external secondary instances
             final ReferenceManager referenceManager = ReferenceManager.instance();
             referenceManager.addReferenceFactory(new StubReferenceFactory());
+
+            PrototypeManager.registerPrototype("org.opendatakit.validate.StubSetGeopointAction");
+            XFormParser.registerActionHandler(StubSetGeopointActionHandler.ELEMENT_NAME, new StubSetGeopointActionHandler());
 
             // validate if the xform can be parsed.
             try {

--- a/src/org/opendatakit/validate/StubSetGeopointAction.java
+++ b/src/org/opendatakit/validate/StubSetGeopointAction.java
@@ -1,0 +1,22 @@
+package org.opendatakit.validate;
+
+import org.javarosa.core.model.actions.setgeopoint.SetGeopointAction;
+import org.javarosa.core.model.instance.TreeReference;
+
+/**
+ * An odk:setgeopoint implementation that does nothing when triggered.
+ */
+public final class StubSetGeopointAction extends SetGeopointAction {
+    public StubSetGeopointAction() {
+        // empty body for serialization
+    }
+
+    StubSetGeopointAction(TreeReference targetReference) {
+        super(targetReference);
+    }
+
+    @Override
+    public void requestLocationUpdates() {
+
+    }
+}

--- a/src/org/opendatakit/validate/StubSetGeopointActionHandler.java
+++ b/src/org/opendatakit/validate/StubSetGeopointActionHandler.java
@@ -9,8 +9,11 @@ import org.javarosa.core.model.actions.setgeopoint.SetGeopointActionHandler;
 public final class StubSetGeopointActionHandler extends SetGeopointActionHandler {
     @Override
     public SetGeopointAction getSetGeopointAction() {
-        // We'd like to use the default constructor but then the name wouldn't be set because the default constructor
-        // has to have an empty body for serialization. Instead, set a null reference and let handle set the target.
+        // We'd like to use the default constructor but then the name field defined in Action wouldn't be set. 
+        // This is because the default constructor has to have an empty body for serialization. Instead, we've
+        // defined a constructor in StubSetGeopointAction that takes in a TreeReference (and sets the name field). 
+        // We can pass in null since we don't know the target node at this point and SetGeopointActionHandler's 
+        // handle() method will set the target.
         return new StubSetGeopointAction(null);
     }
 }

--- a/src/org/opendatakit/validate/StubSetGeopointActionHandler.java
+++ b/src/org/opendatakit/validate/StubSetGeopointActionHandler.java
@@ -1,0 +1,16 @@
+package org.opendatakit.validate;
+
+import org.javarosa.core.model.actions.setgeopoint.SetGeopointAction;
+import org.javarosa.core.model.actions.setgeopoint.SetGeopointActionHandler;
+
+/**
+ * Set an implementation that does nothing.
+ */
+public final class StubSetGeopointActionHandler extends SetGeopointActionHandler {
+    @Override
+    public SetGeopointAction getSetGeopointAction() {
+        // We'd like to use the default constructor but then the name wouldn't be set because the default constructor
+        // has to have an empty body for serialization. Instead, set a null reference and let handle set the target.
+        return new StubSetGeopointAction(null);
+    }
+}


### PR DESCRIPTION
The default stub from JavaRosa writes a string out which fails if the target node type is e.g. geopoint.

Needed to address https://github.com/XLSForm/pyxform/issues/351

#### What has been done to verify that this works as intended?
I tried [metadata.xml.txt](https://github.com/opendatakit/validate/files/3586013/metadata.xml.txt) before the fix, confirmed it fails because of a casting issue, applied the fix, confirmed that it works.

#### Why is this the best possible solution? Were any other approaches considered?
I considered changing the stub implementation in JavaRosa to write something in geopoint format, probably 0 0 0 0, but I think it's helpful for JR tests to have the "no implementation" text and I think it makes it more likely clients would notice they've made a mistake if they don't register their own action handler.

For Validate, having the action do nothing is ideal. We can't do that at the JR level because it doesn't allow us to test that the basic action setup (abstract SetGeopointAction class) works.

#### Are there any risks to merging this code? If so, what are they?
I can't think of any. This only affects forms that have setgeopoint actions. It adds support for those forms and I think the only risk is that it doesn't work in some contexts.