### PR TITLE
Update JavaRosa for new odk:recordaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile group: 'org.getodk', name: 'javarosa', version: '3.0.0'
+    compile group: 'org.getodk', name: 'javarosa', version: '3.1.0'
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
     testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-all:1.3'


### PR DESCRIPTION
#### What has been done to verify that this works as intended?

Locally replaced the validate JAR in pyxform to check this allowed corect validation of forms with `odk:recordaction`.

#### Why is this the best possible solution? Were any other approaches considered?

Just an update needed to bring in JavaRosa support for the action.

#### Are there any risks to merging this code? If so, what are they?

None I'm aware of!
