### PR TITLE
Add back jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,7 @@ sourceCompatibility = '1.8'
 
 dependencies {
     compile group: 'net.sf.kxml', name: 'kxml2', version: '2.3.0'
-    compile (group: 'org.getodk', name: 'javarosa', version: '4.4.1') {
-        exclude group: "com.fasterxml.jackson.core" // Validate doesn't validate attached geoJSON files
-    }
+    compile (group: 'org.getodk', name: 'javarosa', version: '4.4.1')
     compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
     testCompile 'junit:junit:4.13.2'
     testCompile 'org.hamcrest:hamcrest-all:1.3'


### PR DESCRIPTION
Closes #94

I https://github.com/getodk/validate/pull/93 I convinced myself we didn't need the jackson dependency because geoJSON files aren't validated but currently there is an attempt to parse them.

Longer term I would like to see if we can do some kind of stubbing so we don't need to have the geojson and csv dependencies but for now I think we should get geojson support back first.